### PR TITLE
FIX: Bug in threshold tollerance calculation for determining similarity

### DIFF
--- a/tree_diff/similar_tree.py
+++ b/tree_diff/similar_tree.py
@@ -80,7 +80,7 @@ def condition_similarity(condition1: Condition, condition2: Condition):
 
     # Handle <= as a special case as per paper
     if condition1.operator == Operator.LE and condition2.operator == Operator.LE:
-        t = PERMISSIBLE_DELTA * condition1.threshold
+        t = abs(PERMISSIBLE_DELTA * condition1.threshold)
         x = abs(condition1.threshold - condition2.threshold)
         if x == 0:
             return 1


### PR DESCRIPTION
Consider the following lines:
```
        t = ...
        x = abs(condition1.threshold - condition2.threshold)
        ...
        return 1 - (x / t) if x < t else 0
```

As `x` (the difference between the two thresholds) is a ratio of `t`, then `t` should be the tollerance above which two thresholds are considred different. The tollerance may be proportional to the threshold, e.g. `PERMISSIBLE_DELTA * condition1.threshold`, but `PERMISSIBLE_DELTA * condition1.threshold + condition1.threshold` makes no sense (e.g. consider the case where `condition1.threshold` is negative).